### PR TITLE
Improve poly(A)/poly(T) artifact detection and transcript assembly

### DIFF
--- a/bundle.h
+++ b/bundle.h
@@ -339,8 +339,8 @@ struct BundleData {
  GList<CPrediction> pred;
  int numNascents=0; //number of nascent transcripts generated for this bundle
  RC_BundleData* rc_data; // read count data for this bundle
- GHashMap<uint, GVec<int>*> forbid_src;  
- GHashMap<uint, GVec<int>*> forbid_snk;
+ GHashSet<uint> forbid_src;  
+ GHashSet<uint> forbid_snk;
  BundleData():status(BUNDLE_STATUS_CLEAR), idx(0), start(0), end(0),
 		 numreads(0),
 		 num_fragments(0), frag_len(0),sum_cov(0),covflags(0),

--- a/bundle.h
+++ b/bundle.h
@@ -339,12 +339,14 @@ struct BundleData {
  GList<CPrediction> pred;
  int numNascents=0; //number of nascent transcripts generated for this bundle
  RC_BundleData* rc_data; // read count data for this bundle
+ GHashMap<uint, GVec<int>*> forbid_src;  
+ GHashMap<uint, GVec<int>*> forbid_snk;
  BundleData():status(BUNDLE_STATUS_CLEAR), idx(0), start(0), end(0),
 		 numreads(0),
 		 num_fragments(0), frag_len(0),sum_cov(0),covflags(0),
 		 refseq(), gseq(NULL), readlist(false,true), //bpcov(1024),
 		 junction(true, true, true),
-		 keepguides(false), ptfs(false), pred(false), rc_data(NULL) {
+		 keepguides(false), ptfs(false), pred(false), rc_data(NULL), forbid_src(), forbid_snk() {
 	 for(int i=0;i<3;i++) 	bpcov[i].setCapacity(4096);
  }
 

--- a/bundle.h
+++ b/bundle.h
@@ -182,11 +182,15 @@ struct CReadAln:public GSeg {
 		TAlnInfo* tinfo;
 		bool in_guide;
 	};
+	bool aligned_polyT:1;
+	bool aligned_polyA:1;
+	bool unaligned_polyT:1;
+	bool unaligned_polyA:1;
 
 	CReadAln(char _strand=0, short int _nh=0,
 			int rstart=0, int rend=0, TAlnInfo* tif=NULL): GSeg(rstart, rend), //name(rname),
 					strand(_strand),nh(_nh), len(0), read_count(0), unitig(false),longread(false),pair_count(),pair_idx(),
-					segs(), juncs(false), tinfo(tif) { }
+					segs(), juncs(false), tinfo(tif), aligned_polyT(false), aligned_polyA(false), unaligned_polyT(false), unaligned_polyA(false) { }
 	CReadAln(CReadAln &rd):GSeg(rd.start,rd.end) { // copy contructor
 		strand=rd.strand;
 		nh=rd.nh;

--- a/rlink.cpp
+++ b/rlink.cpp
@@ -325,76 +325,157 @@ bool mismatch_anchor(CReadAln *rd,char *mdstr,int refstart, bam1_t *b) {
 	return false;
 }
 
-// function detects 10-20 consecutive A's with  80-90% of the bases being A at the match end of the single long read and exclude it from the alignment
-bool genome_polyA_terminated(GSamRecord& brec) {
+// Constants for polyA/T detection
+const int MAX_WINDOW_SIZE = 25;     // Window size for checking poly sequences
+const double MIN_POLY_PERCENT = 0.8; // Minimum percentage of A's or T's required (20/25)
+const int MIN_POLY_LENGTH = 10;     // Minimum number of A's or T's required
+const int MAX_MISMATCHES = MAX_WINDOW_SIZE * (1 - MIN_POLY_PERCENT);// Maximum allowed non-A or non-T bases
 
-	char *readseq=brec.sequence();
-	int len = strlen(readseq);
-
-	// check if there is a polyA tail
-	if(brec.clipR) { // adjust length for softclipping
-		len-=brec.clipR;
-	}
-
-	/*// Ensure there are at least 10 characters in the string --> not likely for long reads
-	if(len<10) {
-		GFREE(readseq);
-		return(false);
-	}*/
-
-	int start_pos = len - 1; // end of potential end sequence
-
-	int a_count=0;
-	int end_count=0;
-	while(start_pos>=0 && end_count<25) { // 20/25=0.8
-		end_count++;
-		if(readseq[start_pos]=='A') a_count++;
-
-		if(end_count-a_count>5) {
-			break; // no need to check further if more than 5 characters were non A's
-		}
-
-		// Check if 'A' characters are over 80%
-		if (a_count>=10 && (double)a_count / end_count >= 0.8) {
-			GFREE(readseq);
-			return(true); // No need to check further if a valid end seq is found
-		}
-
-		start_pos--;
-	}
-
-	// check if there is a polyT start
-	start_pos = brec.clipL;
-
-	/*// Ensure there are at least 10 characters in the string --> not likely
-	if(len-brec.clipL<10) {
-		GFREE(readseq);
-		return(false);
-	}*/
-
-	a_count=0;
-	end_count=0;
-
-	while(start_pos<len && end_count<25) { // 20/25=0.8
-		end_count++;
-		if(readseq[start_pos]=='T') a_count++;
-
-		if(end_count-a_count>5) {
-			break; // no need to check further if more than 5 characters were non T's
-		}
-
-		// Check if 'T' characters are over 80%
-		if (a_count>=10 && (double)a_count / end_count >= 0.8) {
-			GFREE(readseq);
-			return(true); // No need to check further if a valid end seq is found
-		}
-
-		start_pos++;
-	}
-
-	GFREE(readseq);
-	return(false);
+// Check for consecutive T's at start of read
+bool check_aligned_polyT_start(GSamRecord& brec) {
+    char *readseq = brec.sequence();
+	if (!readseq) return false;
+    int len = strlen(readseq);
+    
+    // Adjust start position for left softclipping
+    int start_pos = brec.clipL;
+    int t_count = 0;
+    int pos_count = 0;
+    
+    while(pos_count < MAX_WINDOW_SIZE && (start_pos + pos_count) < len) {
+        if(readseq[start_pos + pos_count] == 'T') t_count++;
+		pos_count++; // pos_count is the number of bases I have checked so far
+        
+        if(pos_count - t_count > MAX_MISMATCHES) {
+            GFREE(readseq);
+                    return false;
+                }
+        
+        if(t_count >= MIN_POLY_LENGTH && (double)t_count / pos_count >= MIN_POLY_PERCENT) {
+            GFREE(readseq);
+                    return true;
+                }
+            }
+    
+    GFREE(readseq);
+    return false;
 }
+
+// Check for consecutive A's at end of read with specified threshold percentage
+bool check_aligned_polyA_end(GSamRecord& brec) {
+    char *readseq = brec.sequence();
+	if (!readseq) return false;
+    int len = strlen(readseq);
+    
+    // Adjust end position for right softclipping
+    int end_pos = len - brec.clipR - 1;
+    int a_count = 0;
+    int pos_count = 0;
+    
+    while(end_pos >= 0 && pos_count < MAX_WINDOW_SIZE) {
+        pos_count++;
+        if(readseq[end_pos] == 'A') a_count++;
+        
+        if(pos_count - a_count > MAX_MISMATCHES) {
+            GFREE(readseq);
+                    return false;
+                }
+        
+        if(a_count >= MIN_POLY_LENGTH && (double)a_count / pos_count >= MIN_POLY_PERCENT) {
+            GFREE(readseq);
+                    return true;
+                }
+        end_pos--;
+    }
+    
+    GFREE(readseq);
+    return false;
+}
+
+
+bool check_unaligned_polyA_end(GSamRecord& brec) {
+    char *readseq = brec.sequence();
+	if (!readseq) return false;
+    int len = strlen(readseq);
+
+    // Number of bases soft-clipped at the right end:
+    // If clipR=0, there's no unaligned segment to check.
+    int clip_len = brec.clipR;
+    if (clip_len <= 0) {
+        GFREE(readseq);
+    return false;
+}
+
+    // Start of the unaligned region is the first base after the aligned portion:
+    // For example, if read length=1000 and clipR=50, the unaligned region is [950..999]
+    int start_pos = len - clip_len; // index of first unaligned base
+    int pos_count = 0;
+    int a_count = 0;
+
+    while (pos_count < MAX_WINDOW_SIZE && (start_pos + pos_count) < len) {
+        if (readseq[start_pos + pos_count] == 'A') {
+            a_count++;
+        }
+        pos_count++;
+
+        // If mismatches exceed MAX_MISMATCHES, stop
+        if ((pos_count - a_count) > MAX_MISMATCHES) {
+            GFREE(readseq);
+            return false;
+        }
+
+        // If we've found enough A's at high enough percentage:
+        if (a_count >= MIN_POLY_LENGTH && (double)a_count / pos_count >= MIN_POLY_PERCENT) {
+            GFREE(readseq);
+            return true;
+        }
+    }
+
+    GFREE(readseq);
+    return false;
+}
+
+bool check_unaligned_polyT_start(GSamRecord& brec) {
+    char *readseq = brec.sequence();
+	if (!readseq) return false;
+    int len = strlen(readseq);
+
+    // Number of bases soft-clipped at the left end:
+    // If clipL=0, there's no unaligned segment at the start.
+    int clip_len = brec.clipL;
+    if (clip_len <= 0) {
+        GFREE(readseq);
+        return false;
+    }
+
+    // We'll scan from index 0 up to clip_len - 1 (the unaligned portion)
+    // or up to MAX_WINDOW_SIZE, whichever is smaller.
+    int pos_count = 0;
+    int t_count = 0;
+    int max_check = (clip_len < MAX_WINDOW_SIZE) ? clip_len : MAX_WINDOW_SIZE;
+
+    while (pos_count < max_check) {
+        if (readseq[pos_count] == 'T') {
+            t_count++;
+        }
+        pos_count++;
+
+        // If mismatches exceed MAX_MISMATCHES, stop
+        if ((pos_count - t_count) > MAX_MISMATCHES) {
+            GFREE(readseq);
+            return false;
+        }
+
+        if (t_count >= MIN_POLY_LENGTH && (double)t_count / pos_count >= MIN_POLY_PERCENT) {
+            GFREE(readseq);
+		return true;
+        }
+    }
+
+    GFREE(readseq);
+    return false;
+}
+
 
 void processRead(int currentstart, int currentend, BundleData& bdata,
 		 GHash<int>& hashread,  GReadAlnData& alndata,bool ovlpguide) { // some false positives should be eliminated here in order to break the bundle
@@ -423,9 +504,14 @@ void processRead(int currentstart, int currentend, BundleData& bdata,
 	bool longr=false;
 	if(longreads|| brec.uval) longr=true; // second alignment is always from mixed reads
 
-	//if(longr && brec.exons.Count()==1) { // if unspliced long read, check to see if it was just picked up by mistake; maybe not for mixed mode?
-	if(longr && brec.exons.Count()==1 && !ovlpguide) { // if unspliced long read, check to see if it was just picked up by mistake; maybe not for mixed mode?
-		if(genome_polyA_terminated(brec)) return; // skip read if it's polyA terminated on the genome
+	//sinlge exon reads do not contribute to junction information and increase bpcov.
+	//2exon reads contribute a junction, but are likely alignment artifacts (not real splice sites)
+	if(longr && brec.exons.Count()<=2 && !ovlpguide) {
+		bool neg_artifact = check_aligned_polyT_start(brec); // || !check_unaligned_polyT_start(brec);
+		bool pos_artifact = check_aligned_polyA_end(brec); //|| !check_unaligned_polyA_end(brec);
+		if(neg_artifact || pos_artifact) {
+			return;
+		}
 	}
 
 

--- a/rlink.h
+++ b/rlink.h
@@ -76,12 +76,13 @@ struct CTransfrag {
 	int guide;
 	uint longstart; // for long reads: min start of all longreads sharing transfrag
 	uint longend; // for long reads: max end of all longreads sharing transfrag
-	CTransfrag(GVec<int>& _nodes,GBitVec& bit, float abund=0, bool treal=false, int tguide=0,float sr=0):nodes(_nodes),pattern(bit),abundance(abund),srabund(sr),path(),usepath(-1),weak(-1),real(treal),longread(false),shortread(false),guide(tguide),longstart(false),longend(false) {}
-	CTransfrag(float abund=0, bool treal=false,int tguide=0):nodes(),pattern(),abundance(abund),srabund(0),path(),usepath(-1),weak(-1),real(treal),longread(false),shortread(false),guide(tguide),longstart(false),longend(false) {
+	bool is_artifact:1; // set if this transfrag is an artifact
+	CTransfrag(GVec<int>& _nodes,GBitVec& bit, float abund=0, bool treal=false, int tguide=0,float sr=0):nodes(_nodes),pattern(bit),abundance(abund),srabund(sr),path(),usepath(-1),weak(-1),real(treal),longread(false),shortread(false),guide(tguide),longstart(false),longend(false),is_artifact(false) {}
+	CTransfrag(float abund=0, bool treal=false,int tguide=0):nodes(),pattern(),abundance(abund),srabund(0),path(),usepath(-1),weak(-1),real(treal),longread(false),shortread(false),guide(tguide),longstart(false),longend(false),is_artifact(false) {
 	}
 };
 
-struct CMTransfrag { // this is the super-class for transfrag -> to use in case of merging transcripts
+struct CMTransfrag { // this is the super-class for transfrag -> to use in case of merging trans ipts
 	CTransfrag *transfrag;
 	GVec<int> read; // all reads' indeces that are connected to this transfrag
 	int nf;


### PR DESCRIPTION
## Summary
This PR improves StringTie's handling of poly(A) and poly(T) tails that are incorrectly aligned as exons. These artifacts can lead to inaccurate transcript models, especially at transcript boundaries.

## Changes
- Added new methods for assigning aligned and unaligned poly(A)/poly(T) sequences
- Updated CReadAln struct to track aligned and unaligned poly(A)/poly(T) sequences
- Implemented trimming of reads in readlist that contain artifacts 
- Updated CTransFrag struct to track whether a transfrag is an artifact (assigned after update_abundance is called)
- Added forbidden position maps (forbid_src, forbid_snk) to prevent paths from connecting to src/snk in artifact regions
- Modified path finding to skip transfrags marked as artifacts (fwd_to_sink and back_to_source)
- Added filtering to avoid groups consisting primarily of artifact reads (keeptrf filtering prior to inclusion in trflong)
- Added exon trimming logic for more accurate transcript boundary detection (if last/first exon is >80% polyA/T)
